### PR TITLE
Fix Content Security Policy violations

### DIFF
--- a/src/content-scripts/content_script.js
+++ b/src/content-scripts/content_script.js
@@ -1,15 +1,3 @@
-// content-script.js
-const injectScript = (filePath, tag) => {
-  var node = document.getElementsByTagName(tag)[0];
-  var script = document.createElement("script");
-  script.setAttribute("type", "text/javascript");
-  script.setAttribute("src", filePath);
-  node.appendChild(script);
-};
-//injectScript(chrome.runtime.getURL('web_accessible_resources.js'), 'body');
-injectScript(chrome.runtime.getURL("dd.js"), "body");
-injectScript(chrome.runtime.getURL("event.js"), "body");
-
 /**
  * Format and download in Ten-ho format
  * feature->Automatic login after screen transition, submitted to NAGA analysis

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -18,6 +18,14 @@
       "js": ["content_script.js"]
     },
     {
+      "matches": ["https://game.mahjongsoul.com/*",
+      "https://mahjongsoul.game.yo-star.com/*",
+      "https://game.maj-soul.net/*",
+      "https://game.maj-soul.com/*"],
+      "js": ["dd.js", "event.js"],
+      "world": "MAIN"
+    },
+    {
       "matches": ["https://naga.dmv.nico/naga_report/order_form/"],
       "js": ["content_script_naga.js"]
     },


### PR DESCRIPTION
Edge Version 130.0.2849.46 や Chrome 130.0.6723.59 にて雀魂牌譜検討サポーターを使おうとすると牌譜を読み込めない状況でした。
コンソールを見てみると以下のエラーが出ていました。

<img width="1164" alt="Screenshot 2024-10-20 at 14 17 05" src="https://github.com/user-attachments/assets/534753eb-5492-4ab9-8c18-1b80659f063b">

Content Security Policy の違反が起きていたとのことですが、 `unsafe-inline` を許可することはもうできなくなっていました。

このプルリクエストでは、スクリプトタグのappendChildをしなくてもdd.js, event.js が読み込まれるようにしています。

修正後は牌譜が読み込まれるようになったことを手元で確認しました。
